### PR TITLE
Use correct variable to specify output tar file

### DIFF
--- a/dgxos5/dgxos5.json
+++ b/dgxos5/dgxos5.json
@@ -42,7 +42,7 @@
             "inline_shebang": "/bin/bash -e",
             "inline": [
                 "source ../scripts/setup-nbd",
-                "TGZ_NAME='dgxos5.tar.gz'",
+                "OUTPUT='dgxos5.tar.gz'",
                 "source ../scripts/tar-root"
             ]
         }


### PR DESCRIPTION
As found by @dholt , the variable used to specify the output path was [changed upstream](https://github.com/DeepOps/packer-maas/commit/71f4ff003ba46dae58dc38defd18d49b870e7488#diff-b0ed06ad77a0031f4fcc96735c2e14778efc212f477d9edf11fd9744a69bb279) after the initial testing of the DGX OS recipe.

This PR swaps to use the new variable name.

## Test plan

Built an image and got a file with the right name!